### PR TITLE
Add bkeepers gem to manage environment vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 /yarn-error.log
 
 .byebug_history
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,8 @@ gem 'jquery-rails'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  # A Ruby gem to load environment variables from `.env`.
+  gem 'dotenv-rails' 
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,10 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.3)
+    dotenv (2.2.1)
+    dotenv-rails (2.2.1)
+      dotenv (= 2.2.1)
+      railties (>= 3.2, < 5.2)
     erubi (1.6.0)
     execjs (2.7.0)
     factory_girl (4.8.0)
@@ -212,6 +216,7 @@ DEPENDENCIES
   byebug
   coffee-rails (~> 4.2)
   devise
+  dotenv-rails
   factory_girl_rails
   faker (~> 1.6, >= 1.6.3)
   jbuilder (~> 2.5)


### PR DESCRIPTION
Added bkeepers gem to handle environment variables. 
Everyone should create their own .env file the root directory and exclude it from Git.